### PR TITLE
Update Sportsnet's feed URL

### DIFF
--- a/providers/SNET.js
+++ b/providers/SNET.js
@@ -14,7 +14,7 @@
 
 
   All sports are provided in a single feed at
-  https://d290qmen6zswb.cloudfront.net/ticker
+  https://mobile-statsv2.sportsnet.ca/ticker
 
   The feed takes one parameter:
 
@@ -109,7 +109,7 @@ module.exports = {
     // console.log("Get SNET JSON");
     var self = this;
 
-    var url = "https://d290qmen6zswb.cloudfront.net/ticker?day=" + this.gameDate.format("YYYY-MM-DD");
+    var url = "https://mobile-statsv2.sportsnet.ca/ticker?day=" + this.gameDate.format("YYYY-MM-DD");
 
     request({url: url, method: "GET"}, function(r_err, response, body) {
 


### PR DESCRIPTION
Update Sportsnet's feed URL from https://d290qmen6zswb.cloudfront.net/ticker  to  https://mobile-statsv2.sportsnet.ca/ticker