### PR TITLE
Update SNET.js - Corrected API hostname

### DIFF
--- a/providers/SNET.js
+++ b/providers/SNET.js
@@ -14,7 +14,7 @@
 
 
   All sports are provided in a single feed at
-  https://mobile-statsv2.sportsnet.ca/ticker
+  https://stats-api.sportsnet.ca/ticker
 
   The feed takes one parameter:
 
@@ -109,7 +109,7 @@ module.exports = {
     // console.log("Get SNET JSON");
     var self = this;
 
-    var url = "https://mobile-statsv2.sportsnet.ca/ticker?day=" + this.gameDate.format("YYYY-MM-DD");
+    var url = "https://stats-api.sportsnet.ca/ticker?day=" + this.gameDate.format("YYYY-MM-DD");
 
 
     axios.get(url)


### PR DESCRIPTION
As per "Games not updating #90", the hostname for the ticker API was changed by Sportsnet from "mobile-statsv2.sportsnet.ca" to "stats-api.sportsnet.ca". This pull request fixes that.